### PR TITLE
Add Testcontainers Tests

### DIFF
--- a/TestMinimalAPI.Data/Config/PersonDbConfig.cs
+++ b/TestMinimalAPI.Data/Config/PersonDbConfig.cs
@@ -5,10 +5,11 @@ namespace TestMinimalAPI.Data.Config;
 
 public static class PersonDbConfig
 {
-    public static IServiceCollection AddPersonDbContext(this IServiceCollection service)
+    private const string ConnectionString = "Server=localhost:5432;Database=test-minimal-api;User Id=postgres;Password=postgres";
+    public static IServiceCollection AddPersonDbContext(this IServiceCollection service, string connectionString = ConnectionString)
     {
         service.AddDbContext<PersonDbContext>(opt => 
-            opt.UseNpgsql("Server=localhost:5432;Database=test-minimal-api;User Id=postgres;Password=postgres"));
+            opt.UseNpgsql(connectionString));
 
         return service;
     }

--- a/TestMinimalAPI.TestcontainerTests/Config/AuthWebApplicationFactory.cs
+++ b/TestMinimalAPI.TestcontainerTests/Config/AuthWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TestMinimalAPI.Data.Config;
+using Xunit;
+
+namespace TestMinimalAPI.TestcontainerTests.Config;
+
+[Collection(DatabaseFixture.CollectionName)]
+public class AuthWebApplicationFactory(DatabaseFixture databaseFixture) : WebApplicationFactory<Program>, IClassFixture<DatabaseFixture>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        databaseFixture.ResetDatabase().Wait();
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<PersonDbContext>()
+                .AddPersonDbContext(databaseFixture.ConnectionString);
+            
+            services
+                .AddAuthentication(FakeAuthHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, FakeAuthHandler>(FakeAuthHandler.SchemeName, opt => { });
+        
+            services.PostConfigure<AuthenticationOptions>(options =>
+            {
+                options.DefaultAuthenticateScheme = FakeAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = FakeAuthHandler.SchemeName;
+            });
+        });
+    }
+}

--- a/TestMinimalAPI.TestcontainerTests/Config/DatabaseFixture.cs
+++ b/TestMinimalAPI.TestcontainerTests/Config/DatabaseFixture.cs
@@ -1,0 +1,112 @@
+using System.Data.Common;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Npgsql;
+using Respawn;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace TestMinimalAPI.TestcontainerTests.Config;
+
+public class DatabaseFixture : IAsyncLifetime
+{
+    public const string CollectionName = "Database";
+
+    private PostgreSqlContainer _dbContainer = null!;
+
+    private IContainer _flywayContainer = null!;
+    
+    private Respawner _respawner = null!;
+    private const string UsernameAndPassword = "postgres";
+    private const string DatabaseName = "test-minimal-api";
+    private const int DatabasePort = 5432;
+
+    public string ConnectionString => _dbContainer.GetConnectionString();
+
+    private DbConnection GetOpenDbConnection()
+    {
+        var connection = new NpgsqlConnection(ConnectionString);
+        connection.Open();
+        return connection;
+    }
+    
+    public async Task ResetDatabase() => await _respawner.ResetAsync(GetOpenDbConnection());
+
+    
+    private string GetRootDirectory()
+    {
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var rootDirectory = currentDirectory[..currentDirectory.IndexOf("/TestMinimalAPI.TestcontainerTests", StringComparison.Ordinal)];
+        return rootDirectory;
+    }
+
+    private string GetFlywayDirectory()
+    {
+        var rootDirectory = GetRootDirectory();
+        var hostFlywayDirectory = Path.Combine(rootDirectory, "infra/migrations/");
+        return hostFlywayDirectory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var network = new NetworkBuilder()
+            .Build();
+        
+        _dbContainer = GetPostgresContainer(network);
+        _flywayContainer = GetFlywayContainer(network);
+        
+        await _dbContainer.StartAsync();
+        await _flywayContainer.StartAsync();
+        await _flywayContainer.GetExitCodeAsync();
+        
+        _respawner = await Respawner.CreateAsync(GetOpenDbConnection(), new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.Postgres,
+            SchemasToInclude = ["public"]
+        });
+    }
+
+    private static PostgreSqlContainer GetPostgresContainer(INetwork network)
+    {
+        return new PostgreSqlBuilder()
+            .WithName("postgres-db")
+            .WithUsername(UsernameAndPassword)
+            .WithPassword(UsernameAndPassword)
+            .WithDatabase(DatabaseName)
+            .WithPortBinding(DatabasePort)
+            .WithNetwork(network)
+            .WithAutoRemove(true)
+            .Build();
+    }
+
+    private IContainer GetFlywayContainer(INetwork network)
+    {
+        return new ContainerBuilder()
+            .WithImage("flyway/flyway:10-alpine")
+            .WithName("flyway-migrations")
+            .WithResourceMapping(GetFlywayDirectory(), "/flyway/sql")
+            .WithEntrypoint("flyway")
+            .WithCommand($"-url=jdbc:postgresql://postgres-db:{DatabasePort}/{DatabaseName}",
+                $"-user={UsernameAndPassword}",
+                $"-password={UsernameAndPassword}",
+                "-connectRetries=20",
+                "-placeholders.env=local",
+                "migrate")
+            .WithNetwork(network)
+            .WithAutoRemove(true)
+            .Build();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dbContainer.StopAsync();
+        await _flywayContainer.StopAsync();
+        
+        await _dbContainer.DisposeAsync();
+        await _flywayContainer.DisposeAsync();
+    }
+}
+
+[CollectionDefinition(DatabaseFixture.CollectionName)]
+public class DatabaseFixtureCollection : ICollectionFixture<DatabaseFixture>;

--- a/TestMinimalAPI.TestcontainerTests/Config/FakeAuthHandler.cs
+++ b/TestMinimalAPI.TestcontainerTests/Config/FakeAuthHandler.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TestMinimalAPI.Config;
+
+namespace TestMinimalAPI.TestcontainerTests.Config;
+
+
+public class FakeAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "TestScheme";
+
+    public FakeAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock) {}
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "TestUser"),
+            new Claim(AuthClaims.Roles, AuthRoles.Test),
+        };
+
+        var identity = new ClaimsIdentity(claims, SchemeName, ClaimTypes.Name, AuthClaims.Roles);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/TestMinimalAPI.TestcontainerTests/Controllers/ApiControllerTests.cs
+++ b/TestMinimalAPI.TestcontainerTests/Controllers/ApiControllerTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TestMinimalAPI.Data.Config;
+using TestMinimalAPI.Data.Models;
+using TestMinimalAPI.TestcontainerTests.Config;
+using Xunit;
+
+namespace TestMinimalAPI.TestcontainerTests.Controllers;
+
+[Collection(DatabaseFixture.CollectionName)]
+public class ApiControllerTests : IClassFixture<AuthWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly PersonDbContext _dbContext;
+
+    public ApiControllerTests(AuthWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+        _dbContext = factory.Services.CreateScope().ServiceProvider.GetRequiredService<PersonDbContext>();
+        _dbContext.People.ExecuteDelete();
+        _dbContext.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetTest_ShouldReturnCreatedStatus()
+    {
+        var result = await _client.GetAsync("/test");
+        
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTestAuth_ShouldReturnSuccessStatus()
+    {
+        var result = await _client.GetAsync("/test/auth");
+        
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetDbRecord_ShouldReturnRecord()
+    {
+        var id = Guid.NewGuid();
+        var person = new Person
+        {
+            Id = id,
+            FirstName = "Jon",
+            LastName = "Tester",
+            Email = "JonTester123@gmail.com"
+        };
+        await _dbContext.People.AddAsync(person);
+        await _dbContext.SaveChangesAsync();
+        var result = await _client.GetFromJsonAsync<Person>($"/test/person/{id}");
+        
+        Assert.Equal(person, result);
+    }
+}

--- a/TestMinimalAPI.TestcontainerTests/TestMinimalAPI.TestcontainerTests.csproj
+++ b/TestMinimalAPI.TestcontainerTests/TestMinimalAPI.TestcontainerTests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="Respawn" Version="6.2.1" />
+        <PackageReference Include="Respawn.Postgres" Version="1.0.15" />
+        <PackageReference Include="Testcontainers" Version="4.4.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\TestMinimalAPI\TestMinimalAPI.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/TestMinimalAPI.sln
+++ b/TestMinimalAPI.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestMinimalApi.IntegrationT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestMinimalAPI.Data", "TestMinimalAPI.Data\TestMinimalAPI.Data.csproj", "{20F8D298-8314-4A3F-BDAF-4141BFA123B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestMinimalAPI.TestcontainerTests", "TestMinimalAPI.TestcontainerTests\TestMinimalAPI.TestcontainerTests.csproj", "{E802C4BF-EC59-4DD5-B634-A41A1D481FE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{20F8D298-8314-4A3F-BDAF-4141BFA123B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20F8D298-8314-4A3F-BDAF-4141BFA123B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20F8D298-8314-4A3F-BDAF-4141BFA123B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E802C4BF-EC59-4DD5-B634-A41A1D481FE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E802C4BF-EC59-4DD5-B634-A41A1D481FE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E802C4BF-EC59-4DD5-B634-A41A1D481FE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E802C4BF-EC59-4DD5-B634-A41A1D481FE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Patrick says:
Added simple Testcontainers with Respawner to reset the DB between tests.

Copilot says:
This pull request introduces a comprehensive testing framework for the `TestMinimalAPI` project, adding integration tests using Testcontainers and enhancing the database configuration for better test isolation. The key changes include the addition of a `DatabaseFixture` for managing a PostgreSQL Testcontainer, a `FakeAuthHandler` for authentication in tests, and test cases for API endpoints.

### Database Configuration and Test Isolation:
* Updated `PersonDbConfig` to allow dynamic database connection strings, improving flexibility for test environments. (`TestMinimalAPI.Data/Config/PersonDbConfig.cs`)
* Added `DatabaseFixture` to manage PostgreSQL Testcontainers, including database initialization, migrations with Flyway, and resetting the database state between tests. (`TestMinimalAPI.TestcontainerTests/Config/DatabaseFixture.cs`)

### Authentication for Tests:
* Implemented `FakeAuthHandler` to simulate authentication during tests, enabling scenarios requiring authenticated requests. (`TestMinimalAPI.TestcontainerTests/Config/FakeAuthHandler.cs`)
* Added `AuthWebApplicationFactory` to configure services and authentication for test environments, integrating with `DatabaseFixture`. (`TestMinimalAPI.TestcontainerTests/Config/AuthWebApplicationFactory.cs`)

### Integration Tests:
* Created `ApiControllerTests` to validate API endpoints, including tests for authentication, database interactions, and endpoint responses. (`TestMinimalAPI.TestcontainerTests/Controllers/ApiControllerTests.cs`)

### Project and Solution Updates:
* Added a new test project `TestMinimalAPI.TestcontainerTests` with dependencies for Testcontainers, Respawn, and xUnit. (`TestMinimalAPI.TestcontainerTests/TestMinimalAPI.TestcontainerTests.csproj`)
* Updated the solution file to include the new test project and its build configurations. (`TestMinimalAPI.sln`) [[1]](diffhunk://#diff-516c26b5775a1a01f64ea131c1a0a70e10bf1462c3d63e5e829cf627a0509420R11-R12) [[2]](diffhunk://#diff-516c26b5775a1a01f64ea131c1a0a70e10bf1462c3d63e5e829cf627a0509420R35-R38)